### PR TITLE
Add die shaped loading spinners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# code editors
+.idea

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -4,7 +4,7 @@ import { App } from "./App";
 import { StubClient } from "./test-objects/StubClient";
 import { generateRoll } from "./test-objects/factories";
 import { act } from "react-dom/test-utils";
-import {ALL_DICE} from './domain/Die'
+import { ALL_DICE } from "./domain/Die";
 
 describe("<App />", () => {
   let stubClient: StubClient;

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -4,6 +4,7 @@ import { App } from "./App";
 import { StubClient } from "./test-objects/StubClient";
 import { generateRoll } from "./test-objects/factories";
 import { act } from "react-dom/test-utils";
+import {ALL_DICE} from './domain/Die'
 
 describe("<App />", () => {
   let stubClient: StubClient;
@@ -51,6 +52,15 @@ describe("<App />", () => {
 
     act(() => stubClient.capturedObserver.onSuccess(generateRoll({})));
     expect(subject.queryByRole("progressbar")).not.toBeInTheDocument();
+  });
+
+  describe("loading animations", () => {
+    ALL_DICE.forEach((die) => {
+      it(`displays a unique loader for a ${die}`, () => {
+        fireEvent.click(subject.getByAltText(die));
+        expect(subject.queryByTitle(`${die}-spinner`)).toBeInTheDocument();
+      });
+    });
   });
 
   it("increments the count and sends", () => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -41,7 +41,7 @@ export const App = (props: Props): ReactElement => {
 
   const displayTotalOrLoader = (): ReactElement => {
     if (isLoading) {
-      return <Loader dieType={loadingDieType}/>;
+      return <Loader dieType={loadingDieType} />;
     } else if (roll) {
       return (
         <div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,8 +23,10 @@ export const App = (props: Props): ReactElement => {
   const [roll, setRoll] = useState<Roll | undefined>(undefined);
   const [count, setCount] = useState<number>(1);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [loadingDieType, setIsLoadingDieType] = useState<Die>("d4");
 
   const handleClick = (die: Die): void => {
+    setIsLoadingDieType(die);
     setIsLoading(true);
     props.client.rollDie(die, count, {
       onSuccess: (roll: Roll) => {
@@ -39,7 +41,7 @@ export const App = (props: Props): ReactElement => {
 
   const displayTotalOrLoader = (): ReactElement => {
     if (isLoading) {
-      return <Loader />;
+      return <Loader dieType={loadingDieType}/>;
     } else if (roll) {
       return (
         <div>

--- a/frontend/src/Loader.tsx
+++ b/frontend/src/Loader.tsx
@@ -17,7 +17,7 @@ export const Loader = ({ dieType }: LoaderProps): ReactElement => {
 
   return (
     <div className={`loader loader-${dieType}`} role="progressbar" title={`${dieType}-spinner`}>
-      <div className={`base-shape animation_roller ${shapeMap[dieType]}`}></div>
+      <div className={`base-shape animation_roller ${shapeMap[dieType]}`} />
     </div>
   );
 };

--- a/frontend/src/Loader.tsx
+++ b/frontend/src/Loader.tsx
@@ -1,15 +1,34 @@
 import React, { ReactElement } from "react";
+import {Die} from './domain/Die'
 
-export const Loader = (): ReactElement => {
+export interface LoaderProps {
+  dieType: Die;
+}
+
+export const Loader = ({
+  dieType
+                       }: LoaderProps): ReactElement => {
+  // Type aliases cannot be used as a parameter type, so no [key: Die]
+  // in other words....no dice! £pun
+  const shapeMap: {[key: string]: string} = {
+    "d4": "triangle",
+    "d6": "square",
+    "d8": "diamond-narrow",
+    "d10": "diamond-wide",
+    "d12": "hexagon",
+    "d20": "hexagon-tall",
+  };
+
   return (
-    <div className="loader" role="progressbar">
-      <div className="square square_one" />
+    <div className="loader" role="progressbar" title={`${dieType}-spinner`}>
+      <div className={`base-shape animation_roller ${shapeMap[dieType]}`}>
+      </div>
     </div>
   );
 };
 
 // <div className="centering-block" role="progressbar">
 //   <div className="loader centered">
-//     <div className="square square_one"/>
+//     <div className="square animation_roller"/>
 //   </div>
 // </div>

--- a/frontend/src/Loader.tsx
+++ b/frontend/src/Loader.tsx
@@ -6,9 +6,7 @@ export interface LoaderProps {
 }
 
 export const Loader = ({ dieType }: LoaderProps): ReactElement => {
-  // Type aliases cannot be used as a parameter type, so no [key: Die]
-  // in other words....no dice! £pun
-  const shapeMap: { [key: string]: string } = {
+  const shapeMap: Record<Die, string> = {
     d4: "triangle",
     d6: "square",
     d8: "diamond-narrow",

--- a/frontend/src/Loader.tsx
+++ b/frontend/src/Loader.tsx
@@ -18,7 +18,7 @@ export const Loader = ({ dieType }: LoaderProps): ReactElement => {
   };
 
   return (
-    <div className="loader" role="progressbar" title={`${dieType}-spinner`}>
+    <div className={`loader loader-${dieType}`} role="progressbar" title={`${dieType}-spinner`}>
       <div className={`base-shape animation_roller ${shapeMap[dieType]}`}></div>
     </div>
   );

--- a/frontend/src/Loader.tsx
+++ b/frontend/src/Loader.tsx
@@ -1,28 +1,25 @@
 import React, { ReactElement } from "react";
-import {Die} from './domain/Die'
+import { Die } from "./domain/Die";
 
 export interface LoaderProps {
   dieType: Die;
 }
 
-export const Loader = ({
-  dieType
-                       }: LoaderProps): ReactElement => {
+export const Loader = ({ dieType }: LoaderProps): ReactElement => {
   // Type aliases cannot be used as a parameter type, so no [key: Die]
   // in other words....no dice! £pun
-  const shapeMap: {[key: string]: string} = {
-    "d4": "triangle",
-    "d6": "square",
-    "d8": "diamond-narrow",
-    "d10": "diamond-wide",
-    "d12": "hexagon",
-    "d20": "hexagon-tall",
+  const shapeMap: { [key: string]: string } = {
+    d4: "triangle",
+    d6: "square",
+    d8: "diamond-narrow",
+    d10: "diamond-wide",
+    d12: "hexagon",
+    d20: "hexagon-tall",
   };
 
   return (
     <div className="loader" role="progressbar" title={`${dieType}-spinner`}>
-      <div className={`base-shape animation_roller ${shapeMap[dieType]}`}>
-      </div>
+      <div className={`base-shape animation_roller ${shapeMap[dieType]}`}></div>
     </div>
   );
 };

--- a/frontend/src/Loader.tsx
+++ b/frontend/src/Loader.tsx
@@ -26,9 +26,3 @@ export const Loader = ({
     </div>
   );
 };
-
-// <div className="centering-block" role="progressbar">
-//   <div className="loader centered">
-//     <div className="square animation_roller"/>
-//   </div>
-// </div>

--- a/frontend/src/domain/Die.ts
+++ b/frontend/src/domain/Die.ts
@@ -1,4 +1,4 @@
-export const ALL_DICE = ["d4", "d6", "d8", "d10", "d12", "d20"] as const;
+export const ALL_DICE = ["d4", "d6", "d8", "d10", "d12", "d20"];
 
 type ElementType<T extends ReadonlyArray<unknown>> = T extends ReadonlyArray<infer ElementType>
   ? ElementType

--- a/frontend/src/domain/Die.ts
+++ b/frontend/src/domain/Die.ts
@@ -1,3 +1,7 @@
-export const ALL_DICE = ["d4", "d6", "d8", "d10", "d12", "d20"];
+export const ALL_DICE = ["d4", "d6", "d8", "d10", "d12", "d20"] as const;
 
-export type Die = typeof ALL_DICE[number];
+type ElementType<T extends ReadonlyArray<unknown>> = T extends ReadonlyArray<infer ElementType>
+  ? ElementType
+  : never;
+
+export type Die = ElementType<typeof ALL_DICE>;

--- a/frontend/src/styles/loader.scss
+++ b/frontend/src/styles/loader.scss
@@ -4,7 +4,8 @@ $roll-dice-time: $animation-time/4.5;
 .loader {
   animation: roll_dice $roll-dice-time infinite ease-in-out;
 
-  .base-shape, .square {
+  .base-shape,
+  .square {
     background-color: $white;
     width: 20px;
     height: 20px;
@@ -33,7 +34,7 @@ $roll-dice-time: $animation-time/4.5;
   }
   .diamond-narrow:after {
     background: none;
-    content: '';
+    content: "";
     position: absolute;
     left: -13px;
     top: 15px;
@@ -54,7 +55,7 @@ $roll-dice-time: $animation-time/4.5;
   }
   .diamond-wide:after {
     background: none;
-    content: '';
+    content: "";
     position: absolute;
     left: -14px;
     top: 13px;
@@ -73,7 +74,7 @@ $roll-dice-time: $animation-time/4.5;
   }
   .diamond:after {
     background: none;
-    content: '';
+    content: "";
     position: absolute;
     left: -14px;
     top: 14px;
@@ -81,14 +82,15 @@ $roll-dice-time: $animation-time/4.5;
     border-top-color: $white;
   }
 
-  $hex-side-width: .23px;
+  $hex-side-width: 0.23px;
   .hexagon {
     width: 100 * $hex-side-width;
     height: 57.735 * $hex-side-width;
     background: $white;
     position: relative;
   }
-  .hexagon::before, .hexagon::after {
+  .hexagon::before,
+  .hexagon::after {
     content: "";
     position: absolute;
     left: 0;
@@ -106,7 +108,7 @@ $roll-dice-time: $animation-time/4.5;
     border-top: 28.8675 * $hex-side-width solid $white;
   }
 
-  $hex-tall-horizontal-width: .21px;
+  $hex-tall-horizontal-width: 0.21px;
   $hex-tall-vertical-width: 1.1 * $hex-tall-horizontal-width;
   .hexagon-tall {
     width: 100 * $hex-tall-horizontal-width;
@@ -114,7 +116,8 @@ $roll-dice-time: $animation-time/4.5;
     background: $white;
     position: relative;
   }
-  .hexagon-tall::before, .hexagon-tall::after {
+  .hexagon-tall::before,
+  .hexagon-tall::after {
     content: "";
     position: absolute;
     left: 0;

--- a/frontend/src/styles/loader.scss
+++ b/frontend/src/styles/loader.scss
@@ -166,7 +166,6 @@ $roll-dice-time: $animation-time/4.5;
   }
 }
 
-
 @keyframes roll_dice_d4 {
   0% {
     transform: rotate(0deg);

--- a/frontend/src/styles/loader.scss
+++ b/frontend/src/styles/loader.scss
@@ -140,6 +140,10 @@ $roll-dice-time: $animation-time/4.5;
   }
 }
 
+.loader.loader-d4 {
+  animation: roll_dice_d4 $roll-dice-time infinite ease-in-out;
+}
+
 @keyframes roll_dice {
   0% {
     transform: rotate(0deg);
@@ -159,5 +163,28 @@ $roll-dice-time: $animation-time/4.5;
 
   100% {
     transform: rotate(360deg);
+  }
+}
+
+
+@keyframes roll_dice_d4 {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  25% {
+    transform: rotate(360deg);
+  }
+
+  50% {
+    transform: rotate(360deg);
+  }
+
+  75% {
+    transform: rotate(720deg);
+  }
+
+  100% {
+    transform: rotate(720deg);
   }
 }

--- a/frontend/src/styles/loader.scss
+++ b/frontend/src/styles/loader.scss
@@ -2,18 +2,138 @@ $animation-time: 8s;
 $roll-dice-time: $animation-time/4.5;
 
 .loader {
-  animation: roll_dice $roll-dice-time infinite ease-in;
+  animation: roll_dice $roll-dice-time infinite ease-in-out;
 
-  .square {
+  .base-shape, .square {
     background-color: $white;
     width: 20px;
     height: 20px;
     opacity: 1;
     transition: background-color 0.25s;
+    transform-origin: center;
   }
 
-  .square_one {
-    animation: square_one $animation-time infinite;
+  .triangle {
+    background: none;
+    width: 0;
+    height: 0;
+    border-bottom: 20px solid $white;
+    border-left: 10px solid transparent;
+    border-right: 10px solid transparent;
+  }
+
+  .diamond-narrow {
+    background: none;
+    width: 0;
+    height: 0;
+    border: 13px solid transparent;
+    border-bottom: 15px solid $white;
+    position: relative;
+    top: -13px;
+  }
+  .diamond-narrow:after {
+    background: none;
+    content: '';
+    position: absolute;
+    left: -13px;
+    top: 15px;
+    width: 0;
+    height: 0;
+    border: 13px solid transparent;
+    border-top: 15px solid $white;
+  }
+
+  .diamond-wide {
+    background: none;
+    width: 0;
+    height: 0;
+    border: 14px solid transparent;
+    border-bottom: 13px solid $white;
+    position: relative;
+    top: -13px;
+  }
+  .diamond-wide:after {
+    background: none;
+    content: '';
+    position: absolute;
+    left: -14px;
+    top: 13px;
+    width: 0;
+    height: 0;
+    border: 14px solid transparent;
+    border-top: 13px solid $white;
+  }
+
+  .diamond {
+    background: none;
+    border: 14px solid transparent;
+    border-bottom-color: $white;
+    position: relative;
+    top: -14px;
+  }
+  .diamond:after {
+    background: none;
+    content: '';
+    position: absolute;
+    left: -14px;
+    top: 14px;
+    border: 14px solid transparent;
+    border-top-color: $white;
+  }
+
+  $hex-side-width: .23px;
+  .hexagon {
+    width: 100 * $hex-side-width;
+    height: 57.735 * $hex-side-width;
+    background: $white;
+    position: relative;
+  }
+  .hexagon::before, .hexagon::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    width: 0;
+    height: 0;
+    border-left: 50 * $hex-side-width solid transparent;
+    border-right: 50 * $hex-side-width solid transparent;
+  }
+  .hexagon::before {
+    top: -28.8675 * $hex-side-width;
+    border-bottom: 28.8675 * $hex-side-width solid $white;
+  }
+  .hexagon::after {
+    bottom: -28.8675 * $hex-side-width;
+    border-top: 28.8675 * $hex-side-width solid $white;
+  }
+
+  $hex-tall-horizontal-width: .21px;
+  $hex-tall-vertical-width: 1.1 * $hex-tall-horizontal-width;
+  .hexagon-tall {
+    width: 100 * $hex-tall-horizontal-width;
+    height: 57.735 * $hex-tall-vertical-width;
+    background: $white;
+    position: relative;
+  }
+  .hexagon-tall::before, .hexagon-tall::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    width: 0;
+    height: 0;
+    border-left: 50 * $hex-tall-horizontal-width solid transparent;
+    border-right: 50 * $hex-tall-horizontal-width solid transparent;
+  }
+  .hexagon-tall::before {
+    top: -28.8675 * $hex-tall-horizontal-width;
+    border-bottom: 28.8675 * $hex-tall-horizontal-width solid $white;
+  }
+  .hexagon-tall::after {
+    bottom: -28.8675 * $hex-tall-horizontal-width;
+    border-top: 28.8675 * $hex-tall-horizontal-width solid $white;
+  }
+
+  .animation_roller {
+    animation: animation_roller $animation-time infinite;
   }
 }
 


### PR DESCRIPTION
Currently, when one clicks on a die to generate a number, a square spins.  Now: a shape corresponding to the die's 2D profile spins instead! 

Testing: I'm using property based testing, which (while kind of lame) works here since the set of die is limited. 

Drawbacks: The human eye doesn't understand how size works, so the shapes are not _exactly_ the same size. 